### PR TITLE
Add module search filter

### DIFF
--- a/app/routes/modules.tsx
+++ b/app/routes/modules.tsx
@@ -1,16 +1,34 @@
 import { Link } from "react-router";
+import { useState } from "react";
 import modules from "../data/modules";
 
 export default function Modules() {
+  const [searchTerm, setSearchTerm] = useState("");
+
+  const filteredModules = modules.filter((mod) =>
+    mod.title.toLowerCase().includes(searchTerm.toLowerCase()) ||
+    mod.description.toLowerCase().includes(searchTerm.toLowerCase())
+  );
+
   return (
     <div className="container mx-auto p-4">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-3xl font-bold mb-2">Trainingsmodule</h1>
-        <p className="text-gray-600 mb-8">Wähle ein Thema, um dein IS-U-Wissen zu vertiefen:</p>
-        
+        <p className="text-gray-600 mb-4">Wähle ein Thema, um dein IS-U-Wissen zu vertiefen:</p>
+
+        <div className="mb-6">
+          <input
+            type="text"
+            placeholder="Module durchsuchen..."
+            value={searchTerm}
+            onChange={(e) => setSearchTerm(e.target.value)}
+            className="w-full md:w-1/2 p-2 border rounded"
+          />
+        </div>
+
         <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {modules.map((mod) => (
-            <Link 
+          {filteredModules.map((mod) => (
+            <Link
               key={mod.id}
               to={`/modules/${mod.id}`}
               className="block p-6 bg-white rounded-lg shadow-sm hover:shadow-md transition-shadow"
@@ -19,6 +37,9 @@ export default function Modules() {
               <p className="text-gray-600">{mod.description}</p>
             </Link>
           ))}
+          {filteredModules.length === 0 && (
+            <p className="col-span-2 text-gray-500">Keine Module gefunden.</p>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- allow filtering modules on the overview page

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_683f7221df8c8320b766c40e43ddc5e4