### PR TITLE
Add consulting and integration modules

### DIFF
--- a/app/components/simulations/EdiBasicsSim.tsx
+++ b/app/components/simulations/EdiBasicsSim.tsx
@@ -1,0 +1,80 @@
+import React, { useState } from 'react';
+
+const tabs = [
+  {
+    id: 'edifact',
+    title: 'UN/EDIFACT',
+    content: (
+      <>
+        <p className="mb-2">EDIFACT ist ein internationaler EDI-Standard mit Segment-Struktur.</p>
+        <ul className="list-disc list-inside text-sm space-y-1">
+          <li>Nachrichtenarten wie INVOIC, ORDERS oder DESADV</li>
+          <li>Verbreitet in Industrie, Handel und Logistik</li>
+          <li>Benötigt spezialisierte Konverter bzw. Mapping-Tools</li>
+        </ul>
+      </>
+    )
+  },
+  {
+    id: 'protocols',
+    title: 'Übertragungsprotokolle',
+    content: (
+      <>
+        <ul className="list-disc list-inside text-sm space-y-1 mb-3">
+          <li>AS2 – HTTP-basierter Standard mit Signatur und Verschlüsselung</li>
+          <li>OFTP2 – Vor allem in der Automobilindustrie im Einsatz</li>
+          <li>SFTP – Sicherer Dateiübertragungsweg</li>
+          <li>REST/SOAP – Für API-basierte Integrationen</li>
+        </ul>
+      </>
+    )
+  },
+  {
+    id: 'mapping',
+    title: 'Mapping-Beispiel',
+    content: (
+      <>
+        <p className="mb-2">EDIFACT &lt;-&gt; XML (XSLT-Auszug)</p>
+        <pre className="bg-gray-800 text-white p-2 rounded text-xs overflow-x-auto whitespace-pre-wrap mb-2">&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;xsl:stylesheet version="1.0" xmlns:xsl="http://www.w3.org/1999/XSL/Transform"&gt;
+  &lt;xsl:template match="INVOIC"&gt;
+    &lt;Invoice&gt;
+      &lt;xsl:value-of select="BGM/02" /&gt;
+    &lt;/Invoice&gt;
+  &lt;/xsl:template&gt;
+&lt;/xsl:stylesheet&gt;</pre>
+      </>
+    )
+  }
+];
+
+export function EdiBasicsSim() {
+  const [selected, setSelected] = useState('edifact');
+  const tab = tabs.find(t => t.id === selected)!;
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-semibold mb-6">EDI Basics &amp; Protokolle</h2>
+      <div className="mb-4 flex gap-2 flex-wrap">
+        {tabs.map(t => (
+          <button
+            key={t.id}
+            onClick={() => setSelected(t.id)}
+            className={`px-4 py-2 rounded ${selected === t.id ? 'bg-blue-600 text-white' : 'bg-gray-200 hover:bg-gray-300'}`}
+          >
+            {t.title}
+          </button>
+        ))}
+      </div>
+      <div className="bg-white p-4 rounded shadow mb-6">{tab.content}</div>
+      <div className="mt-8 p-4 bg-emerald-50 rounded">
+        <h4 className="font-bold">Lernhinweise:</h4>
+        <ul className="list-disc list-inside space-y-2 text-sm">
+          <li>Grundlagen zu EDI erleichtern das Verständnis von Integrationsprojekten</li>
+          <li>Protokolle wie AS2 oder OFTP2 regeln den sicheren Transport</li>
+          <li>Mapping-Tools transformieren zwischen den Formaten</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/app/components/simulations/PresalesConsultingSim.tsx
+++ b/app/components/simulations/PresalesConsultingSim.tsx
@@ -1,0 +1,74 @@
+import React, { useState } from 'react';
+
+const aspects = [
+  {
+    id: 'storytelling',
+    title: 'Storytelling',
+    content: (
+      <>
+        <ul className="list-disc list-inside text-sm space-y-1 mb-3">
+          <li>Struktur: Problem – Lösung – Nutzen</li>
+          <li>Anschauliche Beispiele und klare Botschaften</li>
+          <li>Präsentationen mit rotem Faden</li>
+        </ul>
+      </>
+    )
+  },
+  {
+    id: 'demo',
+    title: 'Demo-Vorbereitung',
+    content: (
+      <>
+        <ul className="list-disc list-inside text-sm space-y-1 mb-3">
+          <li>Klare Agenda und Zielsetzung definieren</li>
+          <li>Daten und Systeme vorher testen</li>
+          <li>Skript oder Leitfaden bereithalten</li>
+        </ul>
+      </>
+    )
+  },
+  {
+    id: 'consulting',
+    title: 'Consulting-Techniken',
+    content: (
+      <>
+        <ul className="list-disc list-inside text-sm space-y-1 mb-3">
+          <li>Aktives Zuhören und gezielte Fragetechniken</li>
+          <li>Umgang mit Einwänden und schwierigen Situationen</li>
+          <li>Effizientes Zeit- und Erwartungsmanagement</li>
+        </ul>
+      </>
+    )
+  }
+];
+
+export function PresalesConsultingSim() {
+  const [selected, setSelected] = useState('storytelling');
+  const asp = aspects.find(a => a.id === selected)!;
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-semibold mb-6">Presales &amp; Consulting Skills</h2>
+      <div className="mb-4 flex gap-2 flex-wrap">
+        {aspects.map(a => (
+          <button
+            key={a.id}
+            onClick={() => setSelected(a.id)}
+            className={`px-4 py-2 rounded ${selected === a.id ? 'bg-blue-600 text-white' : 'bg-gray-200 hover:bg-gray-300'}`}
+          >
+            {a.title}
+          </button>
+        ))}
+      </div>
+      <div className="bg-white p-4 rounded shadow mb-6">{asp.content}</div>
+      <div className="mt-8 p-4 bg-emerald-50 rounded">
+        <h4 className="font-bold">Empfehlungen:</h4>
+        <ul className="list-disc list-inside space-y-2 text-sm">
+          <li>"The Trusted Advisor" als Literaturtipp</li>
+          <li>YouTube: Presales Demo Techniques</li>
+          <li>LinkedIn Learning: Tech Sales Fundamentals</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/app/components/simulations/SapSDFIIntegrationSim.tsx
+++ b/app/components/simulations/SapSDFIIntegrationSim.tsx
@@ -1,0 +1,75 @@
+import React, { useState } from 'react';
+
+const sections = [
+  {
+    id: 'process',
+    title: 'Rechnungsprozesse in SD/FI',
+    content: (
+      <>
+        <ul className="list-disc list-inside text-sm space-y-1 mb-3">
+          <li>Rechnungserstellung (VF01) aus Fakturabelegen</li>
+          <li>Kontierung und Übergabe an FI bzw. FI-CA</li>
+          <li>Rechnungsprüfung eingehender Belege (MIRO)</li>
+        </ul>
+      </>
+    )
+  },
+  {
+    id: 'idocs',
+    title: 'Wichtige IDoc-Typen',
+    content: (
+      <>
+        <p className="mb-2">Für den Rechnungsaustausch werden häufig genutzt:</p>
+        <ul className="list-disc list-inside text-sm space-y-1">
+          <li>INVOIC01 / INVOIC02 für Ausgangsrechnungen</li>
+          <li>ORDERS / DESADV im vorgelagerten Prozess</li>
+          <li>Custom IDocs je nach Erweiterung</li>
+        </ul>
+      </>
+    )
+  },
+  {
+    id: 'output',
+    title: 'Output Management',
+    content: (
+      <>
+        <ul className="list-disc list-inside text-sm space-y-1 mb-3">
+          <li>Klassisches NAST-Verfahren und moderne BRF+ Lösungen</li>
+          <li>Steuerung von Format und Kanal (z.B. PDF, XML, EDI)</li>
+          <li>Anbindung an Middleware wie SEEBURGER BIS</li>
+        </ul>
+      </>
+    )
+  }
+];
+
+export function SapSDFIIntegrationSim() {
+  const [selected, setSelected] = useState('process');
+  const sec = sections.find(s => s.id === selected)!;
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-semibold mb-6">SAP SD/FI E-Invoicing Integration</h2>
+      <div className="mb-4 flex gap-2 flex-wrap">
+        {sections.map(s => (
+          <button
+            key={s.id}
+            onClick={() => setSelected(s.id)}
+            className={`px-4 py-2 rounded ${selected === s.id ? 'bg-blue-600 text-white' : 'bg-gray-200 hover:bg-gray-300'}`}
+          >
+            {s.title}
+          </button>
+        ))}
+      </div>
+      <div className="bg-white p-4 rounded shadow mb-6">{sec.content}</div>
+      <div className="mt-8 p-4 bg-emerald-50 rounded">
+        <h4 className="font-bold">Tipps:</h4>
+        <ul className="list-disc list-inside space-y-2 text-sm">
+          <li>Kenntnis der SAP-Transaktionen erleichtert Troubleshooting</li>
+          <li>IDoc-Strukturen lassen sich in der Middleware flexibel mappen</li>
+          <li>BRF+ ermöglicht fachliche Steuerung ohne ABAP-Entwicklung</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/app/components/simulations/VidaPeppolInternationalSim.tsx
+++ b/app/components/simulations/VidaPeppolInternationalSim.tsx
@@ -1,0 +1,86 @@
+import React, { useState } from 'react';
+
+const topics = [
+  {
+    id: 'vida',
+    title: 'EU ViDA – VAT in the Digital Age',
+    content: (
+      <>
+        <p className="mb-3">
+          Die ViDA-Initiative der EU soll die Umsatzsteuerprozesse weiter digitalisieren.
+          Geplant sind unter anderem Echtzeit-Meldungen, ein EU-weiter Meldestandard
+          und ein verpflichtender elektronischer Rechnungsaustausch im innergemeinschaftlichen B2B-Bereich.
+        </p>
+        <ul className="list-disc list-inside text-sm space-y-1">
+          <li>Start voraussichtlich ab 2028 mit stufenweiser Einführung</li>
+          <li>Ersetzt in vielen Fällen die bisherige Zusammenfassende Meldung</li>
+          <li>Setzt auf ein einheitliches Datenmodell für Meldungen</li>
+        </ul>
+      </>
+    )
+  },
+  {
+    id: 'peppol',
+    title: 'Peppol-Netzwerk',
+    content: (
+      <>
+        <p className="mb-3">
+          Peppol ermöglicht den sicheren Austausch elektronischer Rechnungen über ein
+          Vier-Ecken-Modell. Access Points und ein Service Metadata Publisher (SMP)
+          sorgen für die Adressierung und den Transport.
+        </p>
+        <ul className="list-disc list-inside text-sm space-y-1">
+          <li>Zertifizierte Access Points vermitteln zwischen Sender und Empfänger</li>
+          <li>SMP speichert Empfangsadressen und unterstützte Dokumenttypen</li>
+          <li>Weit verbreitet in Europa, aber auch global auf dem Vormarsch</li>
+        </ul>
+      </>
+    )
+  },
+  {
+    id: 'intl',
+    title: 'Internationale Anforderungen',
+    content: (
+      <>
+        <p className="mb-3">Viele Länder setzen bereits heute auf obligatorisches E-Invoicing:</p>
+        <ul className="list-disc list-inside text-sm space-y-1">
+          <li>Italien: SdI-Plattform für alle B2B- und B2C-Rechnungen</li>
+          <li>Frankreich: Chorus Pro und demnächst flächendeckende B2B-Pflicht</li>
+          <li>Mexiko: CFDI mit XML-Struktur und behördlicher Freigabe</li>
+          <li>Polen: KSeF als zentrales Rechnungssystem ab 2024/25</li>
+        </ul>
+      </>
+    )
+  }
+];
+
+export function VidaPeppolInternationalSim() {
+  const [selected, setSelected] = useState('vida');
+  const topic = topics.find(t => t.id === selected)!;
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-semibold mb-6">ViDA, Peppol &amp; internationale Vorgaben</h2>
+      <div className="mb-4 flex gap-2 flex-wrap">
+        {topics.map(t => (
+          <button
+            key={t.id}
+            onClick={() => setSelected(t.id)}
+            className={`px-4 py-2 rounded ${selected === t.id ? 'bg-blue-600 text-white' : 'bg-gray-200 hover:bg-gray-300'}`}
+          >
+            {t.title}
+          </button>
+        ))}
+      </div>
+      <div className="bg-white p-4 rounded shadow mb-6">{topic.content}</div>
+      <div className="mt-8 p-4 bg-emerald-50 rounded">
+        <h4 className="font-bold">Lesehinweise:</h4>
+        <ul className="list-disc list-inside space-y-2 text-sm">
+          <li>BMF-Schreiben zur elektronischen Rechnung</li>
+          <li>EU-Kommission: Übersicht zu ViDA</li>
+          <li>Bitkom Whitepaper E-Invoicing</li>
+        </ul>
+      </div>
+    </div>
+  );
+}
+

--- a/app/data/modules.ts
+++ b/app/data/modules.ts
@@ -9,6 +9,10 @@ const modules = [
   { id: "compliance-archiving", title: "Compliance & Archivierung", description: "Rechtskonforme Archivierung von elektronischen Rechnungen", type: 'simulation' },
   { id: "mission-e-invoice-implementation", title: "Consulting Mission: E-Invoicing Implementierung", description: "Simulierter Consultant-Einsatz zur Implementierung einer E-Invoicing-Lösung", type: 'mission' },
   { id: "troubleshooting-invoice-transmission", title: "Troubleshooting: Rechnungsübermittlung", description: "Eine Rechnung wird nicht korrekt übermittelt. Finde und behebe den Fehler!", type: 'simulation' },
+  { id: "vida-peppol-intl", title: "ViDA & Peppol Netzwerk", description: "Überblick über ViDA, Peppol und internationale E-Invoicing-Anforderungen", type: 'simulation' },
+  { id: "sap-sd-fi-integration", title: "SAP SD/FI E-Invoicing Integration", description: "Rechnungsprozesse, IDocs und Output Management in SAP", type: 'simulation' },
+  { id: "edi-basics-protocols", title: "EDI Basics & Protokolle", description: "UN/EDIFACT, AS2, OFTP2, SFTP und mehr", type: 'simulation' },
+  { id: "presales-consulting-skills", title: "Presales & Consulting Skills", description: "Storytelling, Demo-Gestaltung und Umgang mit Kunden", type: 'simulation' },
 ];
 
 export default modules;

--- a/app/routes/modules.$id.tsx
+++ b/app/routes/modules.$id.tsx
@@ -11,6 +11,10 @@ import { IntegrationScenariosSim } from "../components/simulations/IntegrationSc
 import { ComplianceArchivingSim } from "../components/simulations/ComplianceArchivingSim";
 import { EInvoiceImplementationMission } from "../components/missions/EInvoiceImplementationMission";
 import { TroubleshootingInvoiceTransmissionSim } from "../components/simulations/TroubleshootingInvoiceTransmissionSim";
+import { VidaPeppolInternationalSim } from "../components/simulations/VidaPeppolInternationalSim";
+import { SapSDFIIntegrationSim } from "../components/simulations/SapSDFIIntegrationSim";
+import { EdiBasicsSim } from "../components/simulations/EdiBasicsSim";
+import { PresalesConsultingSim } from "../components/simulations/PresalesConsultingSim";
 
 export default function ModuleDetail() {
   const { id } = useParams();
@@ -49,6 +53,14 @@ export default function ModuleDetail() {
           return <ComplianceArchivingSim />;
         case 'troubleshooting-invoice-transmission':
           return <TroubleshootingInvoiceTransmissionSim />;
+        case 'vida-peppol-intl':
+          return <VidaPeppolInternationalSim />;
+        case 'sap-sd-fi-integration':
+          return <SapSDFIIntegrationSim />;
+        case 'edi-basics-protocols':
+          return <EdiBasicsSim />;
+        case 'presales-consulting-skills':
+          return <PresalesConsultingSim />;
         default:
           return <div className="p-4 bg-yellow-50 rounded"><p><i>Die Simulation für dieses Modul wird bald verfügbar sein! 🚧</i></p></div>;
       }


### PR DESCRIPTION
## Summary
- include new modules for ViDA/Peppol/international regulations, SAP SD/FI integration, EDI basics, and presales skills
- render new modules in router
- provide simulation components for each topic

## Testing
- `npm run typecheck`
- `npx tsc`


------
https://chatgpt.com/codex/tasks/task_e_683f73bd09888320814918b3c5acc073