### PR TITLE
Add SAP Customizing basics module

### DIFF
--- a/app/data/modules.ts
+++ b/app/data/modules.ts
@@ -11,6 +11,7 @@ const modules = [
   { id: "troubleshooting-invoice-transmission", category: 'troubleshooting', title: "Troubleshooting: Rechnungsübermittlung", description: "Eine Rechnung wird nicht korrekt übermittelt. Finde und behebe den Fehler!", type: 'simulation' },
   { id: "vida-peppol-intl", category: 'integration', title: "ViDA & Peppol Netzwerk", description: "Überblick über ViDA, Peppol und internationale E-Invoicing-Anforderungen", type: 'simulation' },
   { id: "sap-sd-fi-integration", category: 'sap', title: "SAP SD/FI E-Invoicing Integration", description: "Rechnungsprozesse, IDocs und Output Management in SAP", type: 'simulation' },
+  { id: "sap-customizing-basics", category: 'sap', title: "SAP Customizing Grundlagen", description: "Konfiguration von Nummernkreisen und Prozessparametern im SPRO", type: 'simulation' },
   { id: "edi-basics-protocols", category: 'basics', title: "EDI Basics & Protokolle", description: "UN/EDIFACT, AS2, OFTP2, SFTP und mehr", type: 'simulation' },
   { id: "presales-consulting-skills", category: 'consulting', title: "Presales & Consulting Skills", description: "Storytelling, Demo-Gestaltung und Umgang mit Kunden", type: 'simulation' },
 ];

--- a/app/routes/modules.$id.tsx
+++ b/app/routes/modules.$id.tsx
@@ -15,6 +15,7 @@ import { VidaPeppolInternationalSim } from "../components/simulations/VidaPeppol
 import { SapSDFIIntegrationSim } from "../components/simulations/SapSDFIIntegrationSim";
 import { EdiBasicsSim } from "../components/simulations/EdiBasicsSim";
 import { PresalesConsultingSim } from "../components/simulations/PresalesConsultingSim";
+import { CustomizingSim } from "../components/simulations/CustomizingSim";
 
 export default function ModuleDetail() {
   const { id } = useParams();
@@ -57,6 +58,8 @@ export default function ModuleDetail() {
           return <VidaPeppolInternationalSim />;
         case 'sap-sd-fi-integration':
           return <SapSDFIIntegrationSim />;
+        case 'sap-customizing-basics':
+          return <CustomizingSim />;
         case 'edi-basics-protocols':
           return <EdiBasicsSim />;
         case 'presales-consulting-skills':


### PR DESCRIPTION
## Summary
- add a new learning module `sap-customizing-basics`
- wire the detail route to render the `CustomizingSim` simulation

## Testing
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_684edd6173fc8320ba30debdb6cba57f