### PR TITLE
Clean up IS-U references

### DIFF
--- a/app/components/missions/TariffDisturbanceMission.tsx
+++ b/app/components/missions/TariffDisturbanceMission.tsx
@@ -4,7 +4,7 @@ import { MissionStep } from './MissionStep';
 
 const learningObjectivesTariff = [
   "Verstehen, wie Kundenanfragen zu Tarifproblemen typischerweise eingehen.",
-  "Erste Analyseschritte im SAP IS-U System bei Tarifstörungen kennenlernen.",
+  "Erste Analyseschritte im SAP-System bei Tarifstörungen kennenlernen.",
   "Relevante Transaktionen für die Tarif- und Abrechnungsanalyse identifizieren.",
   "Grundlagen der Kommunikation mit dem Kunden in einem Consulting-Projekt üben.",
   "Verstehen, wie Customizing-Einstellungen die Tarifabrechnung beeinflussen können (Überblick)."
@@ -171,7 +171,7 @@ export const TariffDisturbanceMission: React.FC = () => {
             <p className="mt-4">Du hast wichtige Aspekte der Consultant-Tätigkeit durchlaufen:</p>
             <ul className="list-disc list-inside pl-4 mt-2 text-gray-700">
               <li>Kundenkommunikation und Auftragsannahme</li>
-              <li>Systematische Analyse im SAP IS-U System</li>
+              <li>Systematische Analyse im SAP-System</li>
               <li>Identifikation von Fehlern im Customizing</li>
               <li>Präsentation und Implementierung einer Lösung</li>
             </ul>

--- a/app/components/simulations/BillingSimulation.tsx
+++ b/app/components/simulations/BillingSimulation.tsx
@@ -338,7 +338,7 @@ export function BillingSimulation() {
       <div className="md:col-span-2 mt-6 p-4 bg-blue-50 rounded">
         <h4 className="font-bold">🎓 Lernhinweise:</h4>
         <ul className="list-disc list-inside space-y-2 text-sm">
-          <li>Eine IS-U Rechnung basiert auf mindestens zwei Zählerständen (Anfang und Ende)</li>
+          <li>Eine Rechnung basiert auf mindestens zwei Zählerständen (Anfang und Ende)</li>
           <li>Der Abrechnungszeitraum wird durch die Zählerstände definiert</li>
           <li>Verschiedene Arten der Zählerstandserfassung sind möglich (Ablesung, Selbstablesung, Schätzung)</li>
           <li>Die Rechnung enthält typischerweise Verbrauchspreise, Grundpreise und bereits gezahlte Abschläge</li>
@@ -350,7 +350,7 @@ export function BillingSimulation() {
       <div className="md:col-span-2 mt-8 p-4 bg-blue-50 rounded">
         <h4 className="font-bold">🎓 Lernhinweise (Abrechnung & Fakturierung):</h4>
         <ul className="list-disc list-inside space-y-2 text-sm">
-          <li>Die Abrechnung in SAP IS-U ist ein komplexer Prozess, der Zählerstände, Tarife, Verträge und Stammdaten berücksichtigt, um Rechnungen zu erstellen.</li>
+          <li>Die Abrechnung im SAP-System ist ein komplexer Prozess, der Zählerstände, Tarife, Verträge und Stammdaten berücksichtigt, um Rechnungen zu erstellen.</li>
           <li>Eine wichtige Transaktion ist die `EA00` (Abrechnungslauf), mit der Massenabrechnungen durchgeführt werden können. Einzelne Verträge können auch über `EA22` (Einzelabrechnungssimulation) oder `EA10` (Turnusabrechnung Einzelkunde) simuliert und abgerechnet werden.</li>
           <li>Abrechnungsbelege (`FKK_BILLDOC`) enthalten alle abrechnungsrelevanten Positionen und bilden die Grundlage für die Fakturierung.</li>
           <li>Die Fakturierung (`EA26` - Fakturierungslauf, `EA19` - Einzelfakturierung) erstellt aus den Abrechnungsbelegen die eigentlichen Rechnungen (Druckbelege) und bucht die Forderungen im Vertragskontokorrent (FI-CA).</li>
@@ -366,7 +366,7 @@ export function BillingSimulation() {
               <li>`EL28`: Zählerstandserfassung (für Korrekturen/Nacherfassungen)</li>
             </ul>
           </li>
-          <li>SPRO-Pfade für das Customizing der Abrechnung finden sich typischerweise unter: <i>SAP Utilities - Vertragsabrechnung</i>. Dort werden z.B. Abrechnungsschemata, Tarife, und Buchungsregeln konfiguriert.</li>
+          <li>SPRO-Pfade für das Customizing der Abrechnung befinden sich beispielsweise unter <i>Vertrieb - Vertragsabrechnung</i>. Dort werden unter anderem Abrechnungsschemata, Tarife und Buchungsregeln konfiguriert.</li>
         </ul>
       </div>
     </div>

--- a/app/components/simulations/CustomizingSim.tsx
+++ b/app/components/simulations/CustomizingSim.tsx
@@ -26,111 +26,93 @@ interface Impact {
 export function CustomizingSim() {
   const [spro, setSpro] = useState<CustomizingNode[]>([
     {
-      id: "ISU",
-      name: "IS-U/DEREGULIERT",
-      description: "Grundeinstellungen für IS-U",
+      id: "EINV",
+      name: "E-Invoicing",
+      description: "Grundkonfiguration für elektronische Rechnungen",
       children: [
         {
           id: "BASIC",
-          name: "Grundeinstellungen",
-          description: "Allgemeine IS-U Einstellungen",
+          name: "Grundkonfiguration",
+          description: "Allgemeine Einstellungen",
           settings: [
             {
-              id: "SPARTENSTEUERUNG",
-              name: "Spartensteuerung",
-              type: "SELECT",
-              value: "STROM",
-              options: ["STROM", "GAS", "WASSER"],
+              id: "NUMBER_RANGE",
+              name: "Nummernkreis",
+              type: "INPUT",
+              value: "100000",
               impacts: [
                 {
-                  area: "Geräteverwaltung",
-                  description: "Bestimmt verfügbare Gerätetypen und Messgrößen",
+                  area: "Rechnungsbelege",
+                  description: "Vergabe der Rechnungsnummern",
                   severity: "HIGH"
-                },
-                {
-                  area: "Tarife",
-                  description: "Filtert spartenspezifische Tarifmerkmale",
-                  severity: "MEDIUM"
                 }
               ]
             },
             {
-              id: "BILLINGACTIVE",
-              name: "Fakturierung aktiv",
+              id: "AUTO_POSTING",
+              name: "Automatische Verbuchung",
               type: "CHECKBOX",
               value: true,
               impacts: [
                 {
-                  area: "Abrechnung",
-                  description: "Deaktiviert/Aktiviert die gesamte Rechnungsstellung",
-                  severity: "HIGH"
+                  area: "Buchhaltung",
+                  description: "Steuert die automatische Verbuchung",
+                  severity: "MEDIUM"
                 }
               ]
             }
           ]
         },
         {
-          id: "DEVICE",
-          name: "Geräteverwaltung",
-          description: "Einstellungen für Geräte und Zähler",
+          id: "OUTPUT",
+          name: "Output Management",
+          description: "Kanäle und Formate",
           settings: [
             {
-              id: "AUTOINSTALL",
-              name: "Automatische Installation",
-              type: "CHECKBOX",
-              value: false,
-              impacts: [
-                {
-                  area: "Geräteverwaltung",
-                  description: "Erlaubt automatische Zählerinstallation bei Anlage",
-                  severity: "MEDIUM"
-                }
-              ]
-            },
-            {
-              id: "READINGVALIDATION",
-              name: "Zählerstandsprüfung",
+              id: "CHANNEL",
+              name: "Standard-Ausgabekanal",
               type: "SELECT",
-              value: "STRICT",
-              options: ["NONE", "BASIC", "STRICT"],
+              value: "EMAIL",
+              options: ["EMAIL", "PRINT", "EDI"],
               impacts: [
                 {
-                  area: "Ablesung",
-                  description: "Bestimmt Intensität der Plausibilitätsprüfungen",
-                  severity: "HIGH"
+                  area: "Kommunikation",
+                  description: "Bestimmt, wie Rechnungen versendet werden",
+                  severity: "MEDIUM"
+                }
+              ]
+            },
+            {
+              id: "FORMAT",
+              name: "PDF-Format",
+              type: "SELECT",
+              value: "XRechnung",
+              options: ["XRechnung", "ZUGFeRD"],
+              impacts: [
+                {
+                  area: "Layout",
+                  description: "Wählt das Standard-Format für die PDF-Erzeugung",
+                  severity: "LOW"
                 }
               ]
             }
           ]
         },
         {
-          id: "BILLING",
-          name: "Abrechnung",
-          description: "Abrechnungsrelevante Einstellungen",
+          id: "POSTING",
+          name: "Buchungskreis-Einstellungen",
+          description: "Parameter für die Verbuchung",
           settings: [
             {
-              id: "BILLCYCLE",
-              name: "Abrechnungszyklus",
-              type: "INPUT",
-              value: "12",
+              id: "POST_ACTIVE",
+              name: "Buchung aktiv",
+              type: "CHECKBOX",
+              value: true,
               impacts: [
                 {
-                  area: "Abrechnung",
-                  description: "Standardintervall für Turnusabrechnung (Monate)",
-                  severity: "MEDIUM"
-                }
-              ]
-            },
-            {
-              id: "TOLERANCE",
-              name: "Toleranz Verbrauchsabweichung",
-              type: "INPUT",
-              value: "20",
-              impacts: [
-                {
-                  area: "Abrechnung",
-                  description: "Maximale Abweichung in % vor Prüfprotokoll",
-                  severity: "MEDIUM"
+                  area: "FI",
+                  description: "Aktiviert die automatische Verbuchung von Rechnungen",
+                  severity: "HIGH"
                 }
               ]
             }
@@ -299,13 +281,7 @@ export function CustomizingSim() {
           <li>Customizing-Einstellungen werden in der Regel in Entwicklungssystemen vorgenommen und dann über Transportaufträge (Transaktionen `SE09`, `SE10`) in Test- und Produktivsysteme (`STMS`) übertragen.</li>
           <li>Die Mandantenverwaltung (`SCC4`) legt fest, ob und wie Änderungen in einem Mandanten erlaubt sind.</li>
           <li>Berechtigungen für Customizing-Aktivitäten und den Zugriff auf Transaktionen werden über Rollen in der `PFCG` gesteuert.</li>
-          <li>Viele Einstellungen, die hier simuliert werden (z.B. Spartensteuerung, Abrechnungszyklen), sind tief im SPRO-Pfad unter <i>SAP Utilities</i> zu finden. Beispielpfade könnten sein:
-            <ul className="list-disc list-inside pl-4">
-              <li><i>SAP Customizing Einführungsleitfaden - SAP Utilities - Grundeinstellungen - ...</i></li>
-              <li><i>SAP Customizing Einführungsleitfaden - SAP Utilities - Geräteverwaltung - ...</i></li>
-              <li><i>SAP Customizing Einführungsleitfaden - SAP Utilities - Vertragsabrechnung - ...</i></li>
-            </ul>
-          </li>
+          <li>Viele Einstellungen, die hier simuliert werden (z.B. Nummernkreise oder Outputparameter), befinden sich im SPRO unter <i>Vertrieb - Fakturierung - Elektronische Rechnung</i> oder in ähnlichen Pfaden.</li>
           <li>Es ist entscheidend, die Auswirkungen von Customizing-Änderungen sorgfältig zu testen und zu dokumentieren, bevor sie in produktive Umgebungen übernommen werden.</li>
         </ul>
       </div>

--- a/app/components/simulations/DeviceManagementSim.tsx
+++ b/app/components/simulations/DeviceManagementSim.tsx
@@ -135,10 +135,10 @@ export function DeviceManagementSim() {
           <ul className="list-disc list-inside space-y-2 text-sm">
             <li>Ein Zähler kann verschiedene Status haben: AKTIV, AUSGEBAUT oder DEFEKT (Transaktion: `IQ02`/`IQ03` - Geräte anzeigen/ändern)</li>
             <li>Neue Zählerstände müssen immer höher sein als der letzte erfasste Stand (Transaktion: `EL28` - Ableseerfassung)</li>
-            <li>Die Zählernummer (hier: {devices[0].id}) ist im IS-U ein wichtiges Merkmal zur Identifikation.</li>
+            <li>Die Zählernummer (hier: {devices[0].id}) ist ein wichtiges Merkmal zur Identifikation.</li>
             <li>Der technische Platz (hier: {devices[0].location}) gibt den Einbauort des Zählers an (Transaktion: `IL03` - Technischen Platz anzeigen).</li>
             <li>Wichtige SAP-Transaktionen (Geräteverwaltung): `EG30` (Einbau), `EG31` (Ausbau), `EG32` (Wechsel), `IQ01` (Anlegen), `IQ08` (Suchen), `EL01` (Ableseeinheit), `EL18` (Ableseaufträge).</li>
-            <li>Customizing-Pfade (SPRO, beispielhaft): SAP Utilities - Geräteverwaltung - Stammdaten / Einbau/Ausbau/Wechsel.</li>
+            <li>Customizing-Pfade (SPRO, beispielhaft): Geräteverwaltung - Stammdaten / Einbau/Ausbau/Wechsel.</li>
           </ul>
         </div>
     </div>

--- a/app/components/simulations/IntercompanyTroubleshootingSim.tsx
+++ b/app/components/simulations/IntercompanyTroubleshootingSim.tsx
@@ -85,9 +85,9 @@ Ihre Aufgabe ist es, das Problem zu analysieren.
   };
 
   const handleCheckWLF_IDOC = () => {
-    addLogEntry("Aktion: IS-U spezifisches IDoc Monitoring (WLF_IDOC) prüfen.", true);
+    addLogEntry("Aktion: Branchenspezifisches IDoc Monitoring (WLF_IDOC) prüfen.", true);
     setCurrentSimStep('check_wlf_idoc');
-    addLogEntry("System: In WLF_IDOC werden keine spezifischen IS-U Verarbeitungsprotokolle für den Vorgang gefunden. Dies deutet darauf hin, dass das Problem vor der IS-U spezifischen Verarbeitung auftrat.");
+    addLogEntry("System: In WLF_IDOC werden keine branchenspezifischen Verarbeitungsprotokolle für den Vorgang gefunden. Dies deutet darauf hin, dass das Problem vor dieser speziellen Verarbeitung auftrat.");
   };
 
   const renderInitialStepActions = () => (
@@ -97,7 +97,7 @@ Ihre Aufgabe ist es, das Problem zu analysieren.
       <button onClick={handleCheckEDPARTNER} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">2. Partnervereinbarungen prüfen (EDPARTNER)</button>
       <button onClick={handleCheckWE20} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">3. Partnerprofile prüfen (WE20)</button>
       <button onClick={handleCheckSM59WE21} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">4. Port-Konfiguration prüfen (SM59/WE21)</button>
-      <button onClick={handleCheckWLF_IDOC} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">5. IS-U IDoc Monitoring prüfen (WLF_IDOC)</button>
+      <button onClick={handleCheckWLF_IDOC} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">5. Branchenspezifisches IDoc Monitoring prüfen (WLF_IDOC)</button>
     </div>
   );
 
@@ -132,14 +132,14 @@ Ihre Aufgabe ist es, das Problem zu analysieren.
             <p className="text-md font-semibold mb-2">Port-Konfiguration scheint korrekt. Nächste Schritte?</p>
             <button onClick={handleCheckWE02} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">IDoc Monitoring prüfen (WE02/WE05)</button>
             <button onClick={handleCheckWE20} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">Partnerprofile prüfen (WE20)</button>
-            <button onClick={handleCheckWLF_IDOC} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">IS-U IDoc Monitoring prüfen (WLF_IDOC)</button>
+            <button onClick={handleCheckWLF_IDOC} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">Branchenspezifisches IDoc Monitoring prüfen (WLF_IDOC)</button>
             <button onClick={() => setCurrentSimStep('initial')} className="w-full mt-2 px-4 py-2 bg-amber-500 text-white rounded hover:bg-amber-600 text-left">Zurück zur Haupt-Aktionsauswahl</button>
           </div>
         );
       case 'check_wlf_idoc':
         return (
           <div className="space-y-2">
-            <p className="text-md font-semibold mb-2">Keine IS-U spezifischen Logs in WLF_IDOC. Nächste Schritte?</p>
+            <p className="text-md font-semibold mb-2">Keine branchenspezifischen Logs in WLF_IDOC. Nächste Schritte?</p>
             <button onClick={handleCheckWE02} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">IDoc Monitoring prüfen (WE02/WE05)</button>
             <button onClick={handleCheckWE20} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">Partnerprofile prüfen (WE20)</button>
             <button onClick={handleCheckEDPARTNER} className="w-full px-4 py-2 bg-sky-500 text-white rounded hover:bg-sky-600 text-left">Partnervereinbarungen prüfen (EDPARTNER)</button>

--- a/app/components/simulations/InvoicingAccountingSim.tsx
+++ b/app/components/simulations/InvoicingAccountingSim.tsx
@@ -33,7 +33,7 @@ type SimulationState = 'idle' | 'billingDone' | 'invoicingDone' | 'printDone' | 
 
 const BAPI_EXAMPLES = {
   CREATE_FICA_DOC: `
-// BAPI_ACC_DOCUMENT_POST oder BAPI_ISUACCOUNT_CREATEFROMDATA (vereinfacht)
+// BAPI_ACC_DOCUMENT_POST oder andere FI-CA APIs (vereinfacht)
 {
   DOCUMENTHEADER: {
     BUS_ACT: 'RFBU', // Geschäftsvorgang Hauptbuchhaltung
@@ -247,7 +247,7 @@ export function InvoicingAccountingSim() {
           <li><b>Fehlerbehandlung:</b> Fehlerhafte Fakturabelege (z.B. durch falsche Stammdaten) müssen storniert werden (z.B. via <code>EA20</code> - Fakturierungsstorno). Dies erzeugt oft einen Stornofakturabeleg und entsprechende FI-CA Buchungen.</li>
           <li><b>Wichtige BAPIs:</b>
             <ul className="list-disc list-inside ml-4">
-                <li><code>BAPI_ISUACCOUNT_CREATEFROMDATA</code>: Zum Erstellen von FI-CA Belegen.</li>
+                <li>FI-CA API zum Erstellen von Belegen (z.B. BAPI_ACC_DOCUMENT_POST).</li>
                 <li><code>BAPI_BILLINGDOC_CREATEFROMEXT</code>: Zum externen Erstellen von Abrechnungsbelegen.</li>
                 <li><code>BAPI_INVOICEDOC_CREATEMULTIPLE</code>: Zum Erstellen von Fakturabelegen.</li>
                 <li><code>BAPI_INV_PRINTDOCUMENT_CREATE</code>: Zum Erstellen von Druckbelegen für die Rechnung.</li>

--- a/app/components/simulations/MarketCommunicationSim.tsx
+++ b/app/components/simulations/MarketCommunicationSim.tsx
@@ -187,10 +187,10 @@ export function MarketCommunicationSim() {
           <li>Der <b>Lieferantenwechsel</b> (oft GPKE - Geschäftsprozesse zur Kundenbelieferung mit Elektrizität - genannt) ist ein standardisierter Prozess in der deutschen Energiewirtschaft.</li>
           <li><b>UTILMD</b> ist ein EDIFACT-Nachrichtenformat für Stammdatenänderungen, Anmeldungen, Abmeldungen etc. Es gibt verschiedene Nachrichtentypen (z.B. E01 für Anmeldung).</li>
           <li>Der Netzbetreiber prüft die Anmeldung und sendet eine Bestätigung (oft als CONTRL-Nachricht oder positive UTILMD-Antwort).</li>
-          <li>SAP IS-U verwendet <b>IDocs</b> als internes Format, die dann in EDIFACT-Nachrichten konvertiert werden (und umgekehrt). Die Transaktion <code>WEDI</code> ist die Basis für IDoc-Verwaltung.</li>
-          <li>Im Fehlerfall (z.B. ungültige Daten) sendet der Empfänger eine Fehlernachricht (z.B. APERAK oder negative CONTRL). Solche Fehler können in SAP IS-U im IDoc-Monitoring (<code>BD87</code>) oder speziellen MaKo-Monitoren (<code>EDIMON</code>) analysiert werden.</li>
+          <li>Im SAP-System werden <b>IDocs</b> als internes Format genutzt und bei Bedarf in EDIFACT-Nachrichten konvertiert. Die Transaktion <code>WEDI</code> bildet die Basis für die IDoc-Verwaltung.</li>
+          <li>Im Fehlerfall (z.B. ungültige Daten) sendet der Empfänger eine Fehlernachricht (z.B. APERAK oder negative CONTRL). Solche Fehler lassen sich im IDoc-Monitoring (<code>BD87</code>) oder in speziellen Monitoren (<code>EDIMON</code>) analysieren.</li>
           <li>Weitere wichtige Nachrichten im Prozess sind z.B. MSCONS für die Übermittlung von Zählerständen/Lastgängen.</li>
-          <li>Das Customizing für diese Prozesse (Partnervereinbarungen, Formate, Prozessdefinitionen) ist sehr detailliert und findet sich u.a. unter <i>SAP Utilities - Intercompany Data Exchange</i>.</li>
+          <li>Das Customizing für diese Prozesse (Partnervereinbarungen, Formate, Prozessdefinitionen) befindet sich typischerweise unter <i>Vertrieb - Intercompany Data Exchange</i> im SPRO.</li>
         </ul>
       </div>
     </div>

--- a/app/components/simulations/ProcessStatusSim.tsx
+++ b/app/components/simulations/ProcessStatusSim.tsx
@@ -153,13 +153,13 @@ export function ProcessStatusSim() {
       <div className="mt-8 p-4 bg-emerald-50 rounded">
         <h4 className="font-bold">🎓 Lernhinweise (Einzugsprozess & Status):</h4>
         <ul className="list-disc list-inside space-y-2 text-sm">
-          <li>Der <b>Einzug</b> ist ein zentraler Geschäftsprozess in SAP IS-U, der die Aufnahme eines neuen Kunden und die Versorgung mit Energie initiiert.</li>
+          <li>Der <b>Einzug</b> ist ein zentraler Geschäftsprozess, der die Aufnahme eines neuen Kunden und die Versorgung mit Energie initiiert.</li>
           <li>Typische Schritte umfassen: Anlage des <b>Geschäftspartners</b> (Transaktion <code>BP</code>), Eröffnung eines <b>Vertragskontos</b> (<code>CAA1</code>), Anlage des <b>Vertrags</b> (oft über Einzugsbeleg <code>EC50E</code> oder im CIC via <code>CIC0</code>), und die technische Installation/Zuordnung des <b>Geräts</b> (<code>EG30</code>, <code>EG33</code>).</li>
           <li>Jedes dieser Objekte (Geschäftspartner, Vertragskonto, Vertrag, Gerät, Anlage) besitzt ein <b>Statusnetzwerk</b>, das festlegt, welche Aktionen in welchem Zustand erlaubt sind und welche Statusübergänge möglich sind.</li>
           <li>Beispielsweise kann ein Vertrag erst abgerechnet werden, wenn er den Status 'Aktiv' oder einen vergleichbaren Status hat. Ein Gerät muss den Status 'Eingebaut' haben, um Ableseergebnisse zu erfassen.</li>
           <li>Die korrekte Abfolge und das Erreichen der richtigen Status sind entscheidend für nachfolgende Prozesse wie Ablesung, Abrechnung und Fakturierung.</li>
           <li>Im SAP-System werden diese Prozesse oft durch Workflows unterstützt, die automatisch Folgeaktivitäten anstoßen oder Benutzer zu bestimmten Aktionen auffordern. Transaktion <code>SWI1</code> kann zur Workflow-Analyse genutzt werden.</li>
-           <li>Das Customizing für Status und Prozesse ist umfangreich und findet sich unter den jeweiligen Komponenten im SPRO (z.B. <i>SAP Utilities - Kundenmanagement - Vertrag</i> oder <i>Geräteverwaltung - Gerätemanagement - Statusmanagement</i>).</li>
+           <li>Das Customizing für Status und Prozesse ist umfangreich und findet sich unter den jeweiligen Komponenten im SPRO (z.B. <i>Vertrieb - Kundenmanagement - Vertrag</i> oder <i>Geräteverwaltung - Gerätemanagement - Statusmanagement</i>).</li>
         </ul>
       </div>
     </div>

--- a/app/components/simulations/SecurityRolesSim.tsx
+++ b/app/components/simulations/SecurityRolesSim.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-type Role = 'Administrator' | 'ISU_USER' | 'Read-Only User' | 'No Access';
+type Role = 'Administrator' | 'APP_USER' | 'Read-Only User' | 'No Access';
 
 interface SimulatedData {
   customerName: string;
@@ -29,12 +29,12 @@ const rolePermissions: Record<Role, Partial<Record<keyof SimulatedData, boolean>
     billingAmount: true,
     paymentHistory: true,
   },
-  'ISU_USER': {
+  'APP_USER': {
     customerName: true,
     contractId: true,
     address: true,
     meterReading: true,
-    billingAmount: false, // Example: ISU_USER cannot see financial totals directly
+    billingAmount: false, // Example: APP_USER cannot see financial totals directly
     paymentHistory: false,
   },
   'Read-Only User': {
@@ -56,7 +56,7 @@ const rolePermissions: Record<Role, Partial<Record<keyof SimulatedData, boolean>
 };
 
 export const SecurityRolesSim: React.FC = () => {
-  const [selectedRole, setSelectedRole] = useState<Role>('ISU_USER');
+  const [selectedRole, setSelectedRole] = useState<Role>('APP_USER');
   const [showBapi, setShowBapi] = useState(false);
 
   const getVisibleData = () => {
@@ -84,11 +84,11 @@ export const SecurityRolesSim: React.FC = () => {
 
   const bapiExamplePFCG = `{
   "BAPI_USER_GET_DETAIL": {
-    "USERNAME": "ISU_USER",
+    "USERNAME": "APP_USER",
     "RETURN": {
       "ACTIVITYGROUPS": [
-        { "AGR_NAME": "SAP_ISU_USER_COMPOSITE" },
-        { "AGR_NAME": "Z_ISU_CUSTOM_DISPLAY" }
+        { "AGR_NAME": "SAP_APP_USER_COMPOSITE" },
+        { "AGR_NAME": "Z_APP_CUSTOM_DISPLAY" }
         // ... weitere Rollen / Profile
       ],
       "PROFILES": [
@@ -113,7 +113,7 @@ export const SecurityRolesSim: React.FC = () => {
       <div className="mb-6 p-4 border rounded-md bg-blue-50">
         <h3 className="text-xl font-semibold mb-2 text-blue-700">Lernziele</h3>
         <ul className="list-disc pl-5 text-gray-700">
-          <li>Grundlegendes Verständnis von Rollen und Berechtigungen in SAP IS-U.</li>
+          <li>Grundlegendes Verständnis von Rollen und Berechtigungen im SAP-System.</li>
           <li>Auswirkungen verschiedener Rollen auf die Datensichtbarkeit.</li>
           <li>Wichtige Transaktionen zur Benutzer- und Rollenverwaltung (z.B. SU01, PFCG).</li>
           <li>Beispielhafte BAPIs im Kontext von Benutzerberechtigungen.</li>
@@ -127,7 +127,7 @@ export const SecurityRolesSim: React.FC = () => {
             <strong>Administrator:</strong> Vollzugriff auf alle Daten und Funktionen. Typischerweise für Systembetreuung und Customizing.
           </p>
           <p className="text-sm text-gray-600 mb-1">
-            <strong>ISU_USER (Sachbearbeiter):</strong> Zugriff auf abrechnungsrelevante Daten, Kundeninformationen und Prozesse. Eingeschränkte Berechtigungen für kritische Finanzdaten oder Systemänderungen. Dies ist eine häufig verwendete Standardrolle oder eine Basis für kundenindividuelle Rollen.
+            <strong>APP_USER (Sachbearbeiter):</strong> Zugriff auf abrechnungsrelevante Daten, Kundeninformationen und Prozesse. Eingeschränkte Berechtigungen für kritische Finanzdaten oder Systemänderungen. Dies ist eine häufig verwendete Standardrolle oder eine Basis für kundenindividuelle Rollen.
           </p>
           <p className="text-sm text-gray-600 mb-1">
             <strong>Read-Only User (Anzeigebenutzer):</strong> Kann bestimmte Daten einsehen, aber keine Änderungen vornehmen. Nützlich für Reporting oder Support.
@@ -148,7 +148,7 @@ export const SecurityRolesSim: React.FC = () => {
             className="w-full p-2 border border-gray-300 rounded-md shadow-sm focus:ring-blue-500 focus:border-blue-500"
           >
             <option value="Administrator">Administrator</option>
-            <option value="ISU_USER">ISU_USER (Sachbearbeiter)</option>
+            <option value="APP_USER">APP_USER (Sachbearbeiter)</option>
             <option value="Read-Only User">Read-Only User (Anzeige)</option>
             <option value="No Access">Kein Zugriff</option>
           </select>
@@ -188,7 +188,7 @@ export const SecurityRolesSim: React.FC = () => {
         <ul className="list-disc pl-5 text-sm text-yellow-700">
           <li>Die hier gezeigte Simulation ist stark vereinfacht. Das SAP-Berechtigungssystem ist sehr detailliert und basiert auf Berechtigungsobjekten, Feldern und Werten.</li>
           <li>Rollen werden in der Transaktion <code>PFCG</code> definiert und Benutzern in <code>SU01</code> zugewiesen.</li>
-          <li>Eine typische Rolle wie <code>SAP_ISU_USER_COMPOSITE</code> ist eine Sammelrolle, die viele Einzelrollen für verschiedene Aufgabenbereiche enthält.</li>
+          <li>Eine typische Rolle wie <code>SAP_APP_USER_COMPOSITE</code> ist eine Sammelrolle, die viele Einzelrollen für verschiedene Aufgabenbereiche enthält.</li>
           <li>Sicherheit umfasst auch Aspekte wie Datenschutz, Systemsicherheit und Zugriffskontrollen über verschiedene Ebenen.</li>
         </ul>
       </div>

--- a/app/components/simulations/TariffManagementSim.tsx
+++ b/app/components/simulations/TariffManagementSim.tsx
@@ -259,11 +259,11 @@ export function TariffManagementSim() {
       <div className="mt-6 p-4 bg-blue-50 rounded">
           <h4 className="font-bold">🎓 Lernhinweise:</h4>
           <ul className="list-disc list-inside space-y-2 text-sm">
-            <li>Tarife in IS-U können sehr komplex sein und verschiedene Preisbestandteile haben (z.B. Arbeitspreis, Grundpreis, Leistungspreis).</li>
+            <li>Tarife in SAP können sehr komplex sein und verschiedene Preisbestandteile haben (z.B. Arbeitspreis, Grundpreis, Leistungspreis).</li>
             <li>Die Preisfindung erfolgt über Schemata und Tarifkonditionen (Transaktion: `EA89` - Preissimulation).</li>
             <li>Staffelpreise ändern sich je nach Verbrauchsmenge.</li>
             <li>Wichtige SAP-Transaktionen (Tarife & Preise): `EA30` (Tarifart anlegen), `EA31` (Tarifart ändern), `EA32` (Tarifart anzeigen), `EA88` (Tarife anzeigen), `EA90` (Preise anzeigen).</li>
-            <li>Customizing-Pfade (SPRO, beispielhaft): SAP Utilities - Vertragsabrechnung - Tarifierung / Preisfindung.</li>
+            <li>Customizing-Pfade (SPRO, beispielhaft): Vertrieb - Vertragsabrechnung - Tarifierung / Preisfindung.</li>
           </ul>
         </div>
     </div>

--- a/app/routes/modules.tsx
+++ b/app/routes/modules.tsx
@@ -20,7 +20,7 @@ export default function Modules() {
     <div className="container mx-auto p-4">
       <div className="max-w-4xl mx-auto">
         <h1 className="text-3xl font-bold mb-2">Trainingsmodule</h1>
-        <p className="text-gray-600 mb-4">Wähle ein Thema, um dein IS-U-Wissen zu vertiefen:</p>
+        <p className="text-gray-600 mb-4">Wähle ein Thema, um dein SAP-Wissen zu vertiefen:</p>
 
         <div className="mb-6">
           <input


### PR DESCRIPTION
## Summary
- remove legacy IS-U wording from modules page and training modules
- redesign `SAP Customizing Grundlagen` simulation for generic E‑Invoicing customizing
- rename security role example from ISU_USER to APP_USER
- adjust several learning hints and examples to generic SAP context

## Testing
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_684eeb0591288320a70606aed400dfa7