### PR TITLE
Add improvements page and navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ docker run -p 3000:3000 e-invoicing-navigator
 
 Dieses Repository dient als Demo- und Lernplattform. Es zeigt, wie man mit React Router eine moderne Webanwendung mit Server-Side Rendering und Hot Module Replacement erstellt.
 
+## Ausblick
+
+Weitere Ideen und Verbesserungsvorschläge findest du auf der neuen Seite [Verbesserungen](/improvements). Dort sind mögliche Erweiterungen speziell für Einsteigerinnen und Einsteiger bei SEEBURGER beschrieben.
+
 ---
 
 Erstellt mit ❤️ mithilfe von React Router.

--- a/app/components/Navigation.tsx
+++ b/app/components/Navigation.tsx
@@ -19,11 +19,19 @@ export function Navigation() {
             </Link>
           </li>
           <li>
-            <Link 
-              to="/modules" 
+            <Link
+              to="/modules"
               className={`hover:text-blue-200 ${isActive('/modules') ? 'font-bold' : ''}`}
             >
               Module
+            </Link>
+          </li>
+          <li>
+            <Link
+              to="/improvements"
+              className={`hover:text-blue-200 ${isActive('/improvements') ? 'font-bold' : ''}`}
+            >
+              Verbesserungen
             </Link>
           </li>
         </ul>

--- a/app/routes.ts
+++ b/app/routes.ts
@@ -3,5 +3,6 @@ import { type RouteConfig, index, route } from "@react-router/dev/routes";
 export default [
   index("routes/home.tsx"),
   route("/modules", "routes/modules.tsx"),
-  route("/modules/:id", "routes/modules.$id.tsx")
+  route("/modules/:id", "routes/modules.$id.tsx"),
+  route("/improvements", "routes/improvements.tsx"),
 ] satisfies RouteConfig;

--- a/app/routes/improvements.tsx
+++ b/app/routes/improvements.tsx
@@ -1,0 +1,32 @@
+import type { Route } from "./+types/improvements";
+
+export function meta({}: Route.MetaArgs) {
+  return [
+    { title: "Ausblick & Verbesserungen" },
+    {
+      name: "description",
+      content: "Ideen für zukünftige Erweiterungen des E-Invoicing Navigators",
+    },
+  ];
+}
+
+export default function Improvements() {
+  return (
+    <div className="container mx-auto p-4">
+      <h1 className="text-3xl font-bold mb-4">Mögliche Erweiterungen</h1>
+      <p className="mb-4">
+        Diese Vorschläge richten sich besonders an neue Kolleginnen und Kollegen
+        bei SEEBURGER. Sie sollen Anregungen geben, wie wir den Navigator weiter
+        ausbauen können.
+      </p>
+      <ul className="list-disc pl-6 space-y-2">
+        <li>Interaktive Schritt-für-Schritt Tutorials für typische SAP-Prozesse.</li>
+        <li>Ein Glossar wichtiger Begriffe rund um E-Invoicing und Integration.</li>
+        <li>Fortschrittsanzeige und kleine Quests zum selbständigen Lernen.</li>
+        <li>Sandbox für Testdaten und Experimente mit der SEEBURGER BIS Plattform.</li>
+        <li>Video-Guides und Best-Practices aus realen Kundenprojekten.</li>
+        <li>Checklisten für den Einstieg und weiterführende interne Ressourcen.</li>
+      </ul>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add new route `/improvements` describing potential extensions
- link new page in the navigation bar
- register route in `app/routes.ts`
- mention the new page in the README

## Testing
- `node_modules/.bin/react-router typegen`
- `npm run typecheck`

------
https://chatgpt.com/codex/tasks/task_e_687d47bf64a08320a457b00772c0abfc